### PR TITLE
Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:12.04
+
+RUN apt-get update && apt-get -y install git make gcc wget ruby1.9.3
+RUN locale-gen en_US.UTF-8
+
+ENV LC_ALL=en_US.UTF-8
+ENV LANG=en_US.UTF-8
+
+WORKDIR /root/octopress
+
+CMD gem install bundler && bundle install && rake generate && rake preview
+
+EXPOSE 4000


### PR DESCRIPTION
Basic docker support.
After pulling the repository:
Build the image first:
```
docker build -t torun-jug/octopress .
```
Next, you might run it with:
```
docker run --volume="$PWD:/root/octopress" -p 4000:4000 -it torun-jug/octopress
```
That should pull dependencies generate site and preview it under `http://localhost:4000`